### PR TITLE
Fixing warning

### DIFF
--- a/Controllers/JVSidebarChatWindowController.h
+++ b/Controllers/JVSidebarChatWindowController.h
@@ -6,6 +6,7 @@
 @interface JVSidebarChatWindowController : JVChatWindowController <AICustomTabsViewDelegate> {
 	IBOutlet JVSideSplitView *splitView;
 	IBOutlet NSView *bodyView;
+	IBOutlet NSView *sideView;
 	BOOL _forceSplitViewPosition;
 }
 @end


### PR DESCRIPTION
“Failed to connect (sideView) outlet from (JVSidebarChatWindowController) to (NSView): missing setter or instance variable”

Alternatively, we could delete the connection in IB.
